### PR TITLE
Implement basic Digital Existence scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,27 @@ npm install
 
 ### 2. Environment Setup
 
-Copy `.env.example` to `.env.local` and fill in your API keys:
+Copy `.env.example` to `.env.local` and populate **all** required variables:
 
 ```env
 # Firecrawl API
 FIRECRAWL_API_KEY=your_firecrawl_key
 
-# AI Model APIs (choose your providers)
+# AI Model APIs
 OPENAI_API_KEY=your_openai_key
 ANTHROPIC_API_KEY=your_anthropic_key
 GOOGLE_API_KEY=your_google_key
+COHERE_API_KEY=your_cohere_key
+GROQ_API_KEY=your_groq_key
 
 # Vercel Postgres (auto-populated in production)
 POSTGRES_URL=your_postgres_url
+POSTGRES_PRISMA_URL=your_prisma_url
+POSTGRES_URL_NON_POOLING=your_non_pool_url
+POSTGRES_USER=your_pg_user
+POSTGRES_HOST=your_pg_host
+POSTGRES_PASSWORD=your_pg_password
+POSTGRES_DATABASE=your_pg_db
 
 # NextAuth.js
 NEXTAUTH_SECRET=your_secret_key
@@ -70,6 +78,17 @@ NEXTAUTH_URL=http://localhost:3000
 # OAuth Providers
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
+GITHUB_CLIENT_ID=your_github_client_id
+GITHUB_CLIENT_SECRET=your_github_client_secret
+DISCORD_CLIENT_ID=your_discord_client_id
+DISCORD_CLIENT_SECRET=your_discord_client_secret
+
+# Notifications
+SLACK_WEBHOOK_URL=your_slack_webhook_url
+DISCORD_WEBHOOK_URL=your_discord_webhook_url
+
+# Vercel (optional locally)
+VERCEL_URL=your_vercel_url
 ```
 
 ### 3. Database Setup

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(spec|test).ts']
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
+    "test": "jest",
     "deploy:staging": "bash scripts/deploy-staging.sh",
     "deploy:production": "bash scripts/deploy-production.sh"
   },
@@ -52,6 +53,9 @@
     "dotenv": "^17.0.0",
     "eslint": "^8",
     "eslint-config-next": "14.2.5",
-    "uuid": "^10.0.0"
+    "uuid": "^10.0.0",
+    "@types/jest": "^29.5.11",
+    "ts-jest": "^29.1.1",
+    "jest": "^29.7.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -207,3 +207,96 @@ model ApiUsage {
   @@index([provider])
   @@index([createdAt])
 }
+// Digital Existence Scoring Tables
+model Project {
+  id        String   @id @default(cuid())
+  userId    String
+  domain    String   @unique
+  name      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user                   User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  wallflowerAnalyses     WallflowerAnalysis[]
+  seoAnalyses            SEOAnalysis[]
+  technicalAudits        TechnicalAudit[]
+  paidAdsMetrics         PaidAdsMetric[]
+  operationsAssessments  OperationsAssessment[]
+  deScores               DEScore[]
+}
+
+model WallflowerAnalysis {
+  id        String   @id @default(cuid())
+  projectId String
+  data      Json
+  score     Int
+  createdAt DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId])
+}
+
+model SEOAnalysis {
+  id        String   @id @default(cuid())
+  projectId String
+  data      Json
+  score     Int
+  createdAt DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId])
+}
+
+model TechnicalAudit {
+  id        String   @id @default(cuid())
+  projectId String
+  data      Json
+  score     Int
+  createdAt DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId])
+}
+
+model PaidAdsMetric {
+  id        String   @id @default(cuid())
+  projectId String
+  data      Json
+  score     Int
+  createdAt DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId])
+}
+
+model OperationsAssessment {
+  id        String   @id @default(cuid())
+  projectId String
+  data      Json
+  score     Int
+  createdAt DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId])
+}
+
+model DEScore {
+  id             String   @id @default(cuid())
+  projectId      String
+  version        Int      @default(1)
+  brandScore     Int
+  operationsScore Int
+  paidScore      Int
+  totalScore     Int
+  breakdown      Json
+  createdAt      DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId])
+}

--- a/src/app/api/de-score/route.ts
+++ b/src/app/api/de-score/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/auth'
+import { analyzeProject } from '@/lib/deScore'
+import { z } from 'zod'
+
+const BodySchema = z.object({
+  domain: z.string().url()
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const { domain } = BodySchema.parse(body)
+
+    const result = await analyzeProject(domain, session.user.id)
+
+    return NextResponse.json({ success: true, data: result })
+  } catch (error) {
+    console.error('DE score API error:', error)
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/de-score/page.tsx
+++ b/src/app/de-score/page.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+export default function DEScorePage() {
+  const { data: session } = useSession()
+  const [domain, setDomain] = useState('')
+  const [result, setResult] = useState<any>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setResult(null)
+    try {
+      const res = await fetch('/api/de-score', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ domain })
+      })
+      const data = await res.json()
+      if (data.success) {
+        setResult(data.data)
+      } else {
+        alert(data.error || 'Failed to calculate score')
+      }
+    } catch (err) {
+      console.error(err)
+      alert('Request failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!session) {
+    return (
+      <div className="p-8 text-center">Please sign in to calculate a DE Score.</div>
+    )
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Digital Existence Score</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <input
+              type="url"
+              placeholder="https://example.com"
+              value={domain}
+              onChange={(e) => setDomain(e.target.value)}
+              required
+              className="w-full border p-2 rounded"
+            />
+            <Button type="submit" disabled={loading} className="w-full">
+              {loading ? 'Analyzing...' : 'Analyze Website'}
+            </Button>
+          </form>
+          {result && (
+            <div className="mt-6 space-y-2">
+              <div>Total Score: {result.totalScore}</div>
+              <pre className="text-sm bg-gray-100 p-2 rounded">
+                {JSON.stringify(result.breakdown, null, 2)}
+              </pre>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/lib/ai/__tests__/ai.test.ts
+++ b/src/lib/ai/__tests__/ai.test.ts
@@ -1,0 +1,10 @@
+import { generateAIText } from '../index'
+
+describe('AI helpers', () => {
+  it('throws when api key missing', async () => {
+    const original = process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_API_KEY
+    await expect(generateAIText('test')).rejects.toThrow('OpenAI API key')
+    if (original) process.env.OPENAI_API_KEY = original
+  })
+})

--- a/src/lib/deScore.ts
+++ b/src/lib/deScore.ts
@@ -1,0 +1,107 @@
+import { db } from './db'
+import { scrapeUrl } from './firecrawl'
+
+export interface DEScoreResult {
+  projectId: string
+  brandScore: number
+  operationsScore: number
+  paidScore: number
+  totalScore: number
+  breakdown: Record<string, any>
+}
+
+function average(values: number[]) {
+  if (values.length === 0) return 0
+  const sum = values.reduce((a, b) => a + b, 0)
+  return Math.round(sum / values.length)
+}
+
+export async function analyzeProject(domain: string, userId: string) {
+  // Create or find project
+  const project = await db.project.upsert({
+    where: { domain },
+    update: { updatedAt: new Date() },
+    create: { domain, name: domain, userId }
+  })
+
+  const scraped = await scrapeUrl(domain)
+  const content = scraped.markdown || ''
+  const length = content.length
+
+  const wallflowerScore = Math.min(100, Math.round(length / 1000))
+  const seoScore = Math.min(100, Math.round(length / 800))
+  const technicalScore = Math.min(100, 60)
+  const operationsScore = 70
+  const paidScore = 50
+
+  await db.wallflowerAnalysis.create({
+    data: {
+      projectId: project.id,
+      score: wallflowerScore,
+      data: { contentLength: length }
+    }
+  })
+
+  await db.sEOAnalysis.create({
+    data: {
+      projectId: project.id,
+      score: seoScore,
+      data: { contentLength: length }
+    }
+  })
+
+  await db.technicalAudit.create({
+    data: {
+      projectId: project.id,
+      score: technicalScore,
+      data: { placeholder: true }
+    }
+  })
+
+  await db.paidAdsMetric.create({
+    data: {
+      projectId: project.id,
+      score: paidScore,
+      data: { placeholder: true }
+    }
+  })
+
+  await db.operationsAssessment.create({
+    data: {
+      projectId: project.id,
+      score: operationsScore,
+      data: { placeholder: true }
+    }
+  })
+
+  const brandScore = average([wallflowerScore, seoScore, technicalScore])
+  const totalScore = average([brandScore, operationsScore, paidScore])
+  const breakdown = {
+    wallflowerScore,
+    seoScore,
+    technicalScore,
+    operationsScore,
+    paidScore
+  }
+
+  const deScore = await db.dEScore.create({
+    data: {
+      projectId: project.id,
+      brandScore,
+      operationsScore,
+      paidScore,
+      totalScore,
+      breakdown
+    }
+  })
+
+  const result: DEScoreResult = {
+    projectId: project.id,
+    brandScore,
+    operationsScore,
+    paidScore,
+    totalScore,
+    breakdown
+  }
+  return result
+}


### PR DESCRIPTION
## Summary
- extend Prisma schema with Digital Existence scoring tables
- add `deScore` library for calculating a simple DE Score
- create `/api/de-score` endpoint
- add a DE Score page with a URL form
- document all environment variables
- add Jest test infrastructure

## Testing
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686372c53c34832298fe3e77018249f3